### PR TITLE
Support debugging web worker.

### DIFF
--- a/extension/.vscode/launch.json
+++ b/extension/.vscode/launch.json
@@ -13,6 +13,10 @@
                 "--extensionDevelopmentKind=web",
                 "${workspaceFolder}/../examples"
             ],
+            "outFiles": [
+				"${workspaceFolder}/dist/**/*.js"
+			],
+            "debugWebWorkerHost": true,
             "preLaunchTask": "build"
         }
     ]


### PR DESCRIPTION
`debugWebWorkerHost` is required otherwise breakpoints would be unbound.