### PR TITLE
define language of excalidraw and excalidrawlib extensions

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -235,12 +235,15 @@
                 }
             }
         ],
-        "configurationDefaults": {
-            "files.associations": {
-                "*.excalidraw": "json",
-                "*.excalidrawlib": "json"
+        "languages": [
+            {
+                "id": "json",
+                "extensions": [
+                    ".excalidraw",
+                    ".excalidrawlib"
+                ]
             }
-        },
+        ],
         "menus": {
             "commandPalette": [
                 {


### PR DESCRIPTION
This sets the language ID of `.excalidraw` and `.excalidrawlib` files to `json`. This replaces the configuration defaults, which resulted in a write to user settings.