### PR TITLE
Use `@types/vscode-webview` package

### DIFF
--- a/webview/package-lock.json
+++ b/webview/package-lock.json
@@ -20,6 +20,7 @@
         "@types/mousetrap": "^1.6.9",
         "@types/react": "^18.0.21",
         "@types/react-dom": "^18.0.6",
+        "@types/vscode-webview": "^1.57.5",
         "eslint-config-prettier": "^8.5.0",
         "eslint-plugin-prettier": "^4.2.1",
         "prettier": "^2.7.1",
@@ -3710,6 +3711,12 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.2.tgz",
       "integrity": "sha512-F5DIZ36YVLE+PN+Zwws4kJogq47hNgX3Nx6WyDJ3kcplxyke3XIzB8uK5n/Lpm1HBsbGzd6nmGehL8cPekP+Tg==",
+      "dev": true
+    },
+    "node_modules/@types/vscode-webview": {
+      "version": "1.57.5",
+      "resolved": "https://registry.npmjs.org/@types/vscode-webview/-/vscode-webview-1.57.5.tgz",
+      "integrity": "sha512-iBAUYNYkz+uk1kdsq05fEcoh8gJmwT3lqqFPN7MGyjQ3HVloViMdo7ZJ8DFIP8WOK74PjOEilosqAyxV2iUFUw==",
       "dev": true
     },
     "node_modules/@types/ws": {

--- a/webview/package.json
+++ b/webview/package.json
@@ -31,6 +31,7 @@
     "@types/mousetrap": "^1.6.9",
     "@types/react": "^18.0.21",
     "@types/react-dom": "^18.0.6",
+    "@types/vscode-webview": "^1.57.5",
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-prettier": "^4.2.1",
     "prettier": "^2.7.1",

--- a/webview/src/vscode.ts
+++ b/webview/src/vscode.ts
@@ -6,13 +6,7 @@ import {
 import { ExcalidrawElement } from "@excalidraw/excalidraw/types/element/types";
 import { AppState, BinaryFiles } from "@excalidraw/excalidraw/types/types";
 
-declare global {
-  interface Window {
-    acquireVsCodeApi(): any;
-  }
-}
-
-export const vscode = window.acquireVsCodeApi();
+export const vscode = acquireVsCodeApi();
 
 const textEncoder = new TextEncoder();
 


### PR DESCRIPTION
This change makes use of the [`@types/vscode-webview`](https://www.npmjs.com/package/@types/vscode-webview) package to remove the unsafe `any` vscode API declaration.

I was originally made aware of this, because the way this is currently implemented doesn't work correctly in Theia, see https://github.com/eclipse-theia/theia/issues/13374.