### PR TITLE
Set default theme to `auto`

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -95,7 +95,7 @@
                     "excalidraw.theme": {
                         "description": "Excalidraw theme. Use auto to sync theme with VSCode color theme.",
                         "type": "string",
-                        "default": "light",
+                        "default": "auto",
                         "enum": [
                             "auto",
                             "light",


### PR DESCRIPTION
 Update package.json to Set default theme to auto

This allows the extension to automatically respect the user's preference for light or dark mode.