### PR TITLE
Add newFile command

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,6 @@
+dist/*
+node_modules/*
+*.json
+*.code-snippets
+webview/dist/*
+webview/node_modules/*

--- a/package.json
+++ b/package.json
@@ -42,6 +42,12 @@
             {
                 "command": "excalidraw.newFile",
                 "category": "Excalidraw",
+                "title": "Scene",
+                "icon": "$(color-mode)"
+            },
+            {
+                "command": "excalidraw.newSceneFile",
+                "category": "Excalidraw",
                 "title": "New File",
                 "icon": "$(color-mode)"
             },
@@ -252,6 +258,10 @@
         "menus": {
             "commandPalette": [
                 {
+                    "command": "excalidraw.newFile",
+                    "when": "false"
+                },
+                {
                     "command": "excalidraw.updateTheme",
                     "when": "activeCustomEditorId == 'editor.excalidraw'"
                 },
@@ -307,6 +317,11 @@
                     "command": "excalidraw.updateTheme",
                     "when": "activeCustomEditorId == 'editor.excalidraw'",
                     "group": "navigation"
+                }
+            ],
+            "file/newFile": [
+                {
+                    "command": "excalidraw.newFile"
                 }
             ]
         },

--- a/package.json
+++ b/package.json
@@ -40,6 +40,12 @@
                 "icon": "$(color-mode)"
             },
             {
+                "command": "excalidraw.newFile",
+                "category": "Excalidraw",
+                "title": "New File",
+                "icon": "$(color-mode)"
+            },
+            {
                 "command": "excalidraw.preventDefault",
                 "category": "Excalidraw",
                 "title": "Prevent Default"
@@ -347,6 +353,8 @@
         "package": "npm run build-webview && webpack --mode production --devtool hidden-source-map",
         "vscode:prepublish": "npm run package",
         "lint": "eslint --ext .ts src",
+        "prettier": "prettier --check .",
+        "prettierfix": "prettier --write .",
         "open-in-browser": "vscode-test-web --extensionDevelopmentPath=. ../examples"
     },
     "capabilities": {

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1,4 +1,5 @@
 import * as vscode from "vscode";
+import { newUntitledExcalidrawDocument } from "./utils";
 
 function getConfigurationScope(
   config: vscode.WorkspaceConfiguration,
@@ -86,20 +87,6 @@ function showImage(uri: vscode.Uri, viewColumn?: vscode.ViewColumn) {
     uri,
     "imagePreview.previewEditor",
     viewColumn
-  );
-}
-
-let runningCounter = 0;
-
-async function newUntitledExcalidrawDocument() {
-  runningCounter += 1;
-  const uri = vscode.Uri.parse(
-    `untitled:Untitled-${runningCounter}.excalidraw`
-  );
-  await vscode.commands.executeCommand(
-    "vscode.openWith",
-    uri,
-    "editor.excalidraw"
   );
 }
 

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -89,7 +89,35 @@ function showImage(uri: vscode.Uri, viewColumn?: vscode.ViewColumn) {
   );
 }
 
+async function newFile() {
+  const newFileUri = await vscode.window.showSaveDialog({
+    filters: {
+      "Excalidraw": ["excalidraw"],
+    },
+  });
+
+  if (!newFileUri) {
+    return;
+  }
+
+  try {
+    // create a new file with an empty content to avoid further issues with content detection
+    await vscode.workspace.fs.writeFile(newFileUri, new Uint8Array());
+
+    await vscode.commands.executeCommand(
+      "vscode.openWith",
+      newFileUri,
+      "editor.excalidraw"
+    );
+  } catch (error) {
+    vscode.window.showErrorMessage(`Failed to create new file: ${error}`);
+  }
+}
+
 export function registerCommands(context: vscode.ExtensionContext) {
+  context.subscriptions.push(
+    vscode.commands.registerCommand("excalidraw.newFile", newFile)
+  );
   context.subscriptions.push(
     vscode.commands.registerCommand("excalidraw.updateTheme", updateTheme)
   );
@@ -118,6 +146,6 @@ export function registerCommands(context: vscode.ExtensionContext) {
     )
   );
   context.subscriptions.push(
-    vscode.commands.registerCommand("excalidraw.preventDefault", () => {})
+    vscode.commands.registerCommand("excalidraw.preventDefault", () => { })
   );
 }

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -89,34 +89,23 @@ function showImage(uri: vscode.Uri, viewColumn?: vscode.ViewColumn) {
   );
 }
 
+let runningCounter = 0;
+
+async function newUntitledExcalidrawDocument() {
+  runningCounter += 1;
+  const uri = vscode.Uri.parse(
+    `untitled:Untitled-${runningCounter}.excalidraw`
+  );
+  await vscode.commands.executeCommand(
+    "vscode.openWith",
+    uri,
+    "editor.excalidraw"
+  );
+}
+
 async function newFile() {
-  const newFileUri = await vscode.window.showSaveDialog({
-    filters: {
-      Excalidraw: [
-        "excalidraw",
-        "excalidraw.png",
-        "excalidraw.svg",
-        "excalidraw.json",
-      ],
-      "Excalidraw Png": ["excalidraw.png"],
-      "Excalidraw Svg": ["excalidraw.svg"],
-      "Excalidraw Json": ["excalidraw.json"],
-    },
-  });
-
-  if (!newFileUri) {
-    return;
-  }
-
   try {
-    // create a new file with an empty content to avoid further issues with content detection
-    await vscode.workspace.fs.writeFile(newFileUri, new Uint8Array());
-
-    await vscode.commands.executeCommand(
-      "vscode.openWith",
-      newFileUri,
-      "editor.excalidraw"
-    );
+    await newUntitledExcalidrawDocument();
   } catch (error) {
     vscode.window.showErrorMessage(`Failed to create new file: ${error}`);
   }

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -92,7 +92,15 @@ function showImage(uri: vscode.Uri, viewColumn?: vscode.ViewColumn) {
 async function newFile() {
   const newFileUri = await vscode.window.showSaveDialog({
     filters: {
-      "Excalidraw": ["excalidraw"],
+      Excalidraw: [
+        "excalidraw",
+        "excalidraw.png",
+        "excalidraw.svg",
+        "excalidraw.json",
+      ],
+      "Excalidraw Png": ["excalidraw.png"],
+      "Excalidraw Svg": ["excalidraw.svg"],
+      "Excalidraw Json": ["excalidraw.json"],
     },
   });
 

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -127,6 +127,9 @@ export function registerCommands(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand("excalidraw.newFile", newFile)
   );
   context.subscriptions.push(
+    vscode.commands.registerCommand("excalidraw.newSceneFile", newFile)
+  );
+  context.subscriptions.push(
     vscode.commands.registerCommand("excalidraw.updateTheme", updateTheme)
   );
   context.subscriptions.push(

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -84,9 +84,16 @@ export class ExcalidrawEditorProvider
     uri: vscode.Uri,
     openContext: vscode.CustomDocumentOpenContext
   ): Promise<ExcalidrawDocument> {
-    const content = await vscode.workspace.fs.readFile(
-      openContext.backupId ? vscode.Uri.parse(openContext.backupId) : uri
-    );
+    let content: Uint8Array;
+    if (uri.scheme === "untitled") {
+      content = new TextEncoder().encode(
+        JSON.stringify({ type: "excalidraw", elements: [] })
+      );
+    } else {
+      content = await vscode.workspace.fs.readFile(
+        openContext.backupId ? vscode.Uri.parse(openContext.backupId) : uri
+      );
+    }
     const document = new ExcalidrawDocument(uri, content);
 
     const onDidDocumentChange = document.onDidContentChange(() => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,35 @@
+import * as vscode from "vscode";
+import * as path from 'path';
+
+export function getActiveWorkspace() {
+    const activeEditor = vscode.window.activeTextEditor;
+    if (activeEditor) {
+        const doc = activeEditor.document;
+        const ws = vscode.workspace.getWorkspaceFolder(doc.uri);
+        return ws;
+    }
+
+    const wsf = vscode.workspace.workspaceFolders;
+    if (wsf && wsf.length > 0) {
+        const ws = wsf[0];
+        return ws;
+    }
+    return undefined;
+}
+
+let runningCounter = 0;
+
+export async function newUntitledExcalidrawDocument() {
+    runningCounter += 1;
+    const ws = getActiveWorkspace();
+    let fileName = `Untitled-${runningCounter}.excalidraw`;
+    if (ws) {
+        fileName = path.join(ws.uri.fsPath, fileName);
+    }
+    const uri = vscode.Uri.parse(`untitled:${fileName}`);
+    await vscode.commands.executeCommand(
+        "vscode.openWith",
+        uri,
+        "editor.excalidraw"
+    );
+}


### PR DESCRIPTION
Add commands to create a new file.

Closes #21 , because it specifically mention `untitled`  (I assume non disk saved) files.

## Commands

- Add command `New File` (`excalidraw.newSceneFile`) to the command pallete

  ![image](https://github.com/user-attachments/assets/db9597cd-ceba-46f9-b873-c806a9cac15a)

- Add command `Scene` (`excalidraw.newFile`) to the `File->New File` menu of VSCode

  ![image](https://github.com/user-attachments/assets/ff6ebe7d-3467-45d7-b60a-3830b98c78cd)


## Notes

- To avoid issues with content detection the command ask the user for a location to store the file.
- Added `.gitattributes` to avoid issues on Windows machines
- Added prettier scripts to `package.json`