### PR TITLE
Fix: Cannot import libraries

### DIFF
--- a/webview/src/App.tsx
+++ b/webview/src/App.tsx
@@ -153,7 +153,7 @@ export default function App(props: {
     return () => {
       window.removeEventListener("message", listener);
     };
-  }, []);
+  }, [excalidrawAPI]);
 
   return (
     <div className="excalidraw-wrapper">


### PR DESCRIPTION
### Content
Added `excalidrawAPI` to `useEffect` dependency array to avoid stale function where `excalidrawAPI` is `undefined` and its `updateLibrary` function is not executed. 

### Bug details
- Issue: #157
- The `excalidrawAPI` state value starts as `undefined`, then it's set within the `Excalidraw` child component. `excalidrawAPI` value is set successfully, but the listener function defined in the `useEffect` [here](https://github.com/excalidraw/excalidraw-vscode/blob/master/webview/src/App.tsx#L109), which will call `excalidrawAPI?.updateLibrary` [here](https://github.com/excalidraw/excalidraw-vscode/blob/master/webview/src/App.tsx#L125), is not updated and stays stale (as `undefined`) as the `useEffect` does not include `excalidrawAPI` in its dependency array. Finally, as `updateLibrary` is not executed, the library import is not effective.

### Quick demo

https://github.com/user-attachments/assets/7addb6e8-27eb-4968-932b-805d02c1b4e6




