### PR TITLE
Upgrade to Node 18, Improve Devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,7 +7,7 @@
 		// Update 'VARIANT' to pick a Node version: 18, 16, 14.
 		// Append -bullseye or -buster to pin to an OS version.
 		// Use -bullseye variants on local arm64/Apple Silicon.
-		"args": { "VARIANT": "16-bullseye" }
+		"args": { "VARIANT": "18-bullseye" }
 	},
 
 	// Configure tool-specific properties.
@@ -22,10 +22,10 @@
 	},
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
-	// "forwardPorts": [],
+	"forwardPorts": [3000],
 
 	// Use 'postCreateCommand' to run commands after the container is created.
-	// "postCreateCommand": "yarn install",
+	"postCreateCommand": "npm install && npm install -g @vscode/vsce",
 
 	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
 	"remoteUser": "node",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
         "": {
             "name": "excalidraw-editor",
             "version": "3.8.3",
+            "hasInstallScript": true,
             "dependencies": {
                 "js-base64": "^3.7.2",
                 "path-browserify": "^1.0.1"

--- a/package.json
+++ b/package.json
@@ -370,7 +370,7 @@
         "lint": "eslint --ext .ts src",
         "prettier": "prettier --check .",
         "prettierfix": "prettier --write .",
-        "open-in-browser": "vscode-test-web --extensionDevelopmentPath=. ../examples"
+        "open-in-browser": "vscode-test-web --headless --extensionDevelopmentPath=. ./examples"
     },
     "capabilities": {
         "untrustedWorkspaces": {


### PR DESCRIPTION
I'd like to contribute to this extension (I have a fix for #123 that I think will work) but I am having trouble with the build, especially on Apple Silicon.

I've made a few changes to the devcontainer that also updates the Node version to 18 (from 16). I also set up port forwarding and some postinstall to make it easier to set up and develop from within the container (ex. `--headless` stops the extension from trying to open a browser that isn't installed in the container)

This update works well for me (M4 Pro)! If anyone can test on another platform that would be great.

Example of the update I was getting on Node 16:

```
error during build:
TypeError: crypto$2.getRandomValues is not a function
    at resolveConfig (file:///workspaces/excalidraw-vscode/webview/node_modules/vite/dist/node/chunks/dep-glQox-ep.js:54238:16)
    at async createBuilder (file:///workspaces/excalidraw-vscode/webview/node_modules/vite/dist/node/chunks/dep-glQox-ep.js:51936:18)
    at async CAC.<anonymous> (file:///workspaces/excalidraw-vscode/webview/node_modules/vite/dist/node/cli.js:859:23)
```

I think this is an issue with Vite dependencies that can be resolved, but upgrading seems like the best way forward.

I have two more PRs incoming for:
- Applying Prettier fixes that aren't checked in (#165)
- Propose alternative for #123