### PR TITLE
Fix deleted elements appearing in exports

### DIFF
--- a/webview/src/vscode.ts
+++ b/webview/src/vscode.ts
@@ -15,8 +15,9 @@ const svg2VSCode = async (
   appState: Partial<AppState>,
   files: BinaryFiles
 ) => {
+  const nonDeletedElements = elements.filter((element: any) => !element.isDeleted);
   const svg = await exportToSvg({
-    elements,
+    elements: nonDeletedElements,
     appState,
     files,
   });
@@ -31,8 +32,9 @@ const png2VSCode = async (
   appState: Partial<AppState>,
   files: BinaryFiles
 ) => {
+  const nonDeletedElements = elements.filter((element: any) => !element.isDeleted);
   const blob = await exportToBlob({
-    elements,
+    elements: nonDeletedElements,
     appState,
     files,
     getDimensions(width: number, height: number) {


### PR DESCRIPTION
Fixes #167 and #178

Functions `exportToSvg` and `exportToBlob` are supposed to take only non-deleted elements, as seen [here](https://github.com/excalidraw/excalidraw/blob/216afc36252b793d88777cf85b8f51028a00e8b3/packages/utils/src/export.ts#L29).