### PR TITLE
feat: auto-reload editor on external file changes

### DIFF
--- a/src/document.ts
+++ b/src/document.ts
@@ -8,6 +8,11 @@ export class ExcalidrawDocument implements vscode.CustomDocument {
   private _onDidContentChange = new vscode.EventEmitter<void>();
   public onDidContentChange = this._onDidContentChange.event;
 
+  private _onDidExternalChange = new vscode.EventEmitter<Uint8Array>();
+  public onDidExternalChange = this._onDidExternalChange.event;
+
+  private _isSaving = false;
+
   public readonly contentType;
 
   getContentType(): string {
@@ -45,12 +50,29 @@ export class ExcalidrawDocument implements vscode.CustomDocument {
   }
 
   async save() {
-    this.saveAs(this.uri);
+    this._isSaving = true;
+    await this.saveAs(this.uri);
+    // Delay clearing the flag to avoid racing with the file watcher
+    setTimeout(() => { this._isSaving = false; }, 500);
   }
 
   async update(content: Uint8Array) {
+    this._isSaving = true;
     this.content = content;
     this._onDidContentChange.fire();
+    setTimeout(() => { this._isSaving = false; }, 500);
+  }
+
+  async handleExternalChange() {
+    if (this._isSaving) {
+      return;
+    }
+    const newContent = await vscode.workspace.fs.readFile(this.uri);
+    if (Buffer.from(newContent).equals(Buffer.from(this.content))) {
+      return;
+    }
+    this.content = newContent;
+    this._onDidExternalChange.fire(newContent);
   }
 
   async saveAs(destination: vscode.Uri) {
@@ -66,5 +88,6 @@ export class ExcalidrawDocument implements vscode.CustomDocument {
   dispose(): void {
     this._onDidDispose.fire();
     this._onDidContentChange.dispose();
+    this._onDidExternalChange.dispose();
   }
 }

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -255,6 +255,27 @@ export class ExcalidrawEditor {
       }
     );
 
+    const fileWatcher = vscode.workspace.createFileSystemWatcher(
+      new vscode.RelativePattern(
+        vscode.Uri.joinPath(this.document.uri, ".."),
+        path.basename(this.document.uri.fsPath)
+      )
+    );
+
+    const onDidFileChange = fileWatcher.onDidChange(async () => {
+      await this.document.handleExternalChange();
+    });
+
+    const onDidExternalChange = this.document.onDidExternalChange(
+      (newContent) => {
+        this.webview.postMessage({
+          type: "update-scene",
+          content: Array.from(newContent),
+          contentType: this.document.contentType,
+        });
+      }
+    );
+
     this.webview.html = await this.buildHtmlForWebview({
       content: Array.from(this.document.content),
       contentType: this.document.contentType,
@@ -273,6 +294,9 @@ export class ExcalidrawEditor {
       onDidChangeLibraryConfiguration.dispose();
       onDidChangeLibrary.dispose();
       onDidChangeEmbedConfiguration.dispose();
+      fileWatcher.dispose();
+      onDidFileChange.dispose();
+      onDidExternalChange.dispose();
     });
   }
 

--- a/webview/src/App.tsx
+++ b/webview/src/App.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState, useRef } from "react";
 import {
   Excalidraw,
+  loadFromBlob,
   loadLibraryFromBlob,
   serializeLibraryAsJSON,
   THEME,
@@ -136,6 +137,28 @@ export default function App(props: {
           }
           case "image-params-change": {
             setImageParams(message.imageParams);
+            break;
+          }
+          case "update-scene": {
+            const blob = new Blob(
+              [
+                message.contentType === "image/png"
+                  ? new Uint8Array(message.content)
+                  : new TextDecoder().decode(new Uint8Array(message.content)),
+              ],
+              { type: message.contentType }
+            );
+            const data = await loadFromBlob(blob, null, null);
+            excalidrawAPI?.updateScene({
+              elements: data.elements,
+              appState: data.appState,
+            });
+            if (data.files) {
+              excalidrawAPI?.addFiles(
+                Object.values(data.files)
+              );
+            }
+            break;
           }
         }
       } catch (e) {


### PR DESCRIPTION
## Summary

- Adds a `FileSystemWatcher` that detects when an `.excalidraw` file is modified outside of VS Code (e.g. by a CLI tool, script, or another editor)
- Automatically updates the webview canvas with the new file contents — no manual close/reopen needed
- Includes a save-guard to prevent the watcher from re-triggering on the extension's own saves

## Motivation

When working with tools that programmatically generate or modify `.excalidraw` files, there's currently no way to see changes reflected in the editor without closing and reopening the tab. This makes iterative workflows (e.g. generating diagrams from code) much slower than necessary.

## Changes

- **`src/document.ts`**: Added `onDidExternalChange` event emitter, `handleExternalChange()` method, and `_isSaving` guard to distinguish internal saves from external modifications
- **`src/editor.ts`**: Added a `FileSystemWatcher` scoped to the open document's file, wired to `handleExternalChange()` and posting `update-scene` messages to the webview
- **`webview/src/App.tsx`**: Added handler for the new `update-scene` message type that calls `excalidrawAPI.updateScene()` to refresh the canvas

## Test plan

- [ ] Open a `.excalidraw` file in the editor
- [ ] Modify the file externally (e.g. edit the JSON in another editor or via CLI)
- [ ] Verify the canvas updates automatically without closing/reopening
- [ ] Verify that editing within the Excalidraw editor still works normally (no feedback loops)
- [ ] Verify saving from within the editor doesn't cause a flicker/re-render